### PR TITLE
add findreplace filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ If a panic occurs inside a gtf function, the function will silently swallow the 
 ### Index
 
 * [replace](#replace)
+* [findreplace](#findreplace)
 * [default](#default)
 * [length](#length)
 * [lower](#lower)
@@ -242,6 +243,20 @@ Removes all values of arg from the given string.
 {{ value | replace " " }}
 ```
 If value is "The Go Programming Language", the output will be "TheGoProgrammingLanguage".
+
+
+
+#### findreplace
+
+Replaces all instances of the first argument with the second.
+
+* supported value types : string
+* supported argument types : string
+
+```
+{{ value | findreplace " " "-" }}
+```
+If value is "The Go Programming Language", the output will be "The-Go-Programming-Language".
 
 
 

--- a/gtf.go
+++ b/gtf.go
@@ -26,6 +26,11 @@ var GtfTextFuncMap = textTemplate.FuncMap{
 
 		return strings.Replace(s2, s1, "", -1)
 	},
+	"findreplace": func(s1 string, s2 string, s3 string) string {
+		defer recovery()
+
+		return strings.Replace(s3, s1, s2, -1)
+	},
 	"title": func(s string) string {
 		defer recovery()
 		return strings.Title(s)

--- a/gtf_test.go
+++ b/gtf_test.go
@@ -43,6 +43,9 @@ func TestGtfFuncMap(t *testing.T) {
 	ParseTest(&buffer, "{{ \"The Go Programming Language\" | replace \" \" }}", "")
 	AssertEqual(t, &buffer, "TheGoProgrammingLanguage")
 
+	ParseTest(&buffer, "{{ \"The Go Programming Language\" | findreplace \" \" \"X\" }}", "")
+	AssertEqual(t, &buffer, "TheXGoXProgrammingXLanguage")
+
 	ParseTest(&buffer, "{{ \"the go programming language\" | title }}", "")
 	AssertEqual(t, &buffer, "The Go Programming Language")
 

--- a/gtf_text_test.go
+++ b/gtf_text_test.go
@@ -18,6 +18,9 @@ func TestTextTemplateGtfFuncMap(t *testing.T) {
 	TextTemplateParseTest(&buffer, "{{ \"The Go Programming Language\" | replace \" \" }}", "")
 	AssertEqual(t, &buffer, "TheGoProgrammingLanguage")
 
+	TextTemplateParseTest(&buffer, "{{ \"The Go Programming Language\" | findreplace \" \" \"X\" }}", "")
+	AssertEqual(t, &buffer, "TheXGoXProgrammingXLanguage")
+
 	TextTemplateParseTest(&buffer, "{{ \"The Go Programming Language\" | length }}", "")
 	AssertEqual(t, &buffer, "27")
 


### PR DESCRIPTION
Added a findreplace filter similar to the replace filter, except it allows the user to specify a string to replace the string with.